### PR TITLE
Encourage using this repo for meta discussion

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,19 @@
-# Culture
-Discussion of room culture
+# JavaScript Room
+This is where the culture of the JavaScript room and other meta conversation is discussed.
 
-# This repository serves as a placeholder for discussion. Discussions are held in [this repo's issues](https://github.com/JavaScriptRoom/culture/issues)
+# This repository serves as a place for discussion. Discussions are held in [this repo's issues](https://github.com/JavaScriptRoom/culture/issues).
+
+## Content and Moderation
+
+Issues with the room's content, atmosphere, politics, or the actions of room owners are best discussed here, rather than in the chat itself.
+
+[Click here to report problematic activity.](https://github.com/JavaScriptRoom/culture/issues/new) Room owners and other members will discuss these issues with you, and make changes to the room if necessary.
 
 ## Room Ownership
 [Changes to room ownership](https://github.com/JavaScriptRoom/culture/issues/1) shall be proposed via an issue on this repository. RO proposals will have 72 hours for voting, after which the proposal will be acted on if 50% or more of standing votes are in favour. Exceptions will be made for ROs that are clearly vandalizing or damaging the room, in which case they can have RO status removed immediately, to prevent further damage.
 
 [Click here to request a room owner be added or removed.](https://github.com/JavaScriptRoom/culture/issues/new) Please pin a link to the issue in the JavaScript chat room.
 
-## Issue visibility
+## Issue Visibility
 
 Issues that include voting are to [remain open for at least 72 hours](https://github.com/JavaScriptRoom/culture/issues/12) in order to give owners from different time zones the ability to read and address them. 


### PR DESCRIPTION
I think we need to be more helpful in guiding users to this repo for any complaints about the topics, conversations, people, and especially room owners of Room 17. To this end I've edited the readme and added some clarifying information.

We should avoid discussing these issues extensively in chat itself, as that tends to stir up emotions very quickly, and ROs that aren't present at the time don't get to contribute. If someone complains about being kicked or some other RO action, we should gently point them here, and only kick if they continue to make a disturbance in the room proper.

Thoughts?

If we agree that this is what we want, my next proposal will be to change Caprica's welcome message to include a link to this repo, so new users know where to go when they want to report a problem.